### PR TITLE
Add support for extensions parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ xhr.onreadystatechange = function() {
 
 * `version`: The VMAP version (should be 1.0).
 * `adBreaks`: An array of `VMAPAdBreak` objects.
-* `extensions`: An array of XML nodes for each extension left as-is if any.
+* `extensions`: An array of `Object` with
+    * `children`: `Object` containing all this extension children and their name as the key
+    * `attribute`: `Object` containing all this extension attributes and their name as the key
+    * `value`: All of the text nodes of this extension concatenated
 
 ### VMAPAdBreak
 
@@ -61,7 +64,10 @@ Provides information about an ad break.
 * `trackingEvents`: An array of `Object` with tracking URLs
     * `event`: The name of the event to track for the element. Can be one of breakStart, breakEnd or error.
     * `uri`: The URI of the tracker.
-* `extensions`: An array of XML nodes for each extension left as-is if any.
+* `extensions`: An array of `Object` with
+    * `children`: `Object` containing all this extension children and their name as the key
+    * `attribute`: `Object` containing all this extension attributes and their name as the key
+    * `value`: All of the text nodes of this extension concatenated
 
 #### Methods
 

--- a/spec/adbreak.spec.js
+++ b/spec/adbreak.spec.js
@@ -3,7 +3,11 @@ import { readXMLFile } from './utils';
 
 describe('AdBreaks', () => {
   const xml = readXMLFile('samples/correct-vmap.xml');
+  const xmlWithExtensions = readXMLFile(
+    'samples/correct-vmap-with-extension.xml'
+  );
   const vmap = new VMAP(xml);
+  const vmapWithExtensions = new VMAP(xmlWithExtensions);
 
   describe('#1 ad break', () => {
     const adbreak = vmap.adBreaks[0];
@@ -112,6 +116,50 @@ describe('AdBreaks', () => {
 
       expect(trackingEvents[0].event).toBe('breakStart');
       expect(trackingEvents[0].uri).toBe('http://server.com/breakstart');
+    });
+  });
+
+  describe('Ad break with extensions', () => {
+    const adbreak = vmapWithExtensions.adBreaks[0];
+
+    it('should parse extensions', () => {
+      expect(adbreak.extensions).toEqual([
+        {
+          attributes: {
+            extAttribute: 'extAttribute content',
+            extAttribute2: 'extAttribute2 content'
+          },
+          children: {
+            'vmap:Test': {
+              attributes: {
+                testAttribute: 'testAttribute content',
+                testAttribute2: 'testAttribute2 content'
+              },
+              value: 'Test value'
+            },
+            'vmap:Test2': {
+              attributes: {
+                test2Attribute: 'test2Attribute content',
+                test2Attribute2: 'test2Attribute2 content'
+              },
+              value: 'Test2 value'
+            }
+          },
+          value: 'Extension value'
+        },
+        {
+          children: {
+            'vmap:Child': {
+              attributes: {
+                childAttribute: 'childAttribute content',
+                childAttribute2: 'childAttribute2 content'
+              },
+              value: 'Child value'
+            }
+          },
+          value: 'Extension2 value'
+        }
+      ]);
     });
   });
 });

--- a/spec/adbreak.spec.js
+++ b/spec/adbreak.spec.js
@@ -3,11 +3,7 @@ import { readXMLFile } from './utils';
 
 describe('AdBreaks', () => {
   const xml = readXMLFile('samples/correct-vmap.xml');
-  const xmlWithExtensions = readXMLFile(
-    'samples/correct-vmap-with-extension.xml'
-  );
   const vmap = new VMAP(xml);
-  const vmapWithExtensions = new VMAP(xmlWithExtensions);
 
   describe('#1 ad break', () => {
     const adbreak = vmap.adBreaks[0];
@@ -120,6 +116,10 @@ describe('AdBreaks', () => {
   });
 
   describe('Ad break with extensions', () => {
+    const xmlWithExtensions = readXMLFile(
+      'samples/correct-vmap-with-extension.xml'
+    );
+    const vmapWithExtensions = new VMAP(xmlWithExtensions);
     const adbreak = vmapWithExtensions.adBreaks[0];
 
     it('should parse extensions', () => {
@@ -135,6 +135,7 @@ describe('AdBreaks', () => {
                 testAttribute: 'testAttribute content',
                 testAttribute2: 'testAttribute2 content'
               },
+              children: {},
               value: 'Test value'
             },
             'vmap:Test2': {
@@ -142,18 +143,21 @@ describe('AdBreaks', () => {
                 test2Attribute: 'test2Attribute content',
                 test2Attribute2: 'test2Attribute2 content'
               },
+              children: {},
               value: 'Test2 value'
             }
           },
           value: 'Extension value'
         },
         {
+          attributes: {},
           children: {
             'vmap:Child': {
               attributes: {
                 childAttribute: 'childAttribute content',
                 childAttribute2: 'childAttribute2 content'
               },
+              children: {},
               value: 'Child value'
             }
           },

--- a/spec/parser_utils.spec.js
+++ b/spec/parser_utils.spec.js
@@ -1,0 +1,174 @@
+import {
+  childrenByName,
+  parseNodeText,
+  parseXMLNode
+} from '../src/parser_utils';
+import { readXMLFile } from './utils';
+
+describe('ParserUtils', () => {
+  describe('childrenByName function', () => {
+    const testNode = {
+      childNodes: [
+        {
+          nodeName: 'Test'
+        },
+        {
+          nodeName: 'Test2'
+        },
+        {
+          nodeName: 'vmap:Test'
+        },
+        {
+          nodeName: 'vmap:Test2'
+        },
+        {
+          nodeName: 'Test:Test'
+        },
+        {
+          nodeName: 'Test:Test2'
+        },
+        {
+          nodeName: 'vmap:Test:Test'
+        },
+        {
+          nodeName: 'vmap:'
+        },
+        {
+          nodeName: ''
+        },
+        {
+          nodeName: undefined
+        },
+        {
+          nodeName: null
+        }
+      ]
+    };
+
+    it('should select children named Test', () => {
+      const result = childrenByName(testNode, 'Test');
+
+      expect(result).toEqual([
+        {
+          nodeName: 'Test'
+        },
+        {
+          nodeName: 'vmap:Test'
+        }
+      ]);
+    });
+
+    it('should select children named vmap:Test', () => {
+      const result = childrenByName(testNode, 'vmap:Test');
+
+      expect(result).toEqual([
+        {
+          nodeName: 'Test'
+        },
+        {
+          nodeName: 'vmap:Test'
+        }
+      ]);
+    });
+
+    it('should select children named Test:Test', () => {
+      const result = childrenByName(testNode, 'Test:Test');
+
+      expect(result).toEqual([
+        {
+          nodeName: 'Test:Test'
+        },
+        {
+          nodeName: 'vmap:Test:Test'
+        }
+      ]);
+    });
+
+    it('should select children named vmap:Test:Test', () => {
+      const result = childrenByName(testNode, 'vmap:Test:Test');
+
+      expect(result).toEqual([
+        {
+          nodeName: 'Test:Test'
+        },
+        {
+          nodeName: 'vmap:Test:Test'
+        }
+      ]);
+    });
+  });
+
+  describe('parseNodeText function', () => {
+    const testNode = {
+      childNodes: [
+        {
+          nodeName: 'Test',
+          textContent: 'Wrong'
+        },
+        {
+          nodeName: '#text',
+          textContent: '       Blabla    '
+        },
+        {
+          nodeName: ''
+        },
+        {
+          nodeName: undefined
+        },
+        {
+          nodeName: null
+        },
+        {
+          nodeName: '#text',
+          textContent: '       Blobloblo    '
+        }
+      ]
+    };
+
+    it('should correctly extract text', () => {
+      const result = parseNodeText(testNode);
+
+      expect(result).toEqual('BlablaBlobloblo');
+    });
+  });
+
+  describe('parseXMLNode function', () => {
+    const testXML = readXMLFile('samples/parsing-example.xml');
+
+    const result = parseXMLNode(testXML);
+
+    it('should correctly parse XML', () => {
+      expect(result).toEqual({
+        attributes: {},
+        children: {
+          'vmap:Extension': {
+            attributes: {
+              extAttribute: 'extAttribute content',
+              extAttribute2: 'extAttribute2 content'
+            },
+            children: {
+              'vmap:Test': {
+                attributes: {
+                  testAttribute: 'testAttribute content',
+                  testAttribute2: 'testAttribute2 content'
+                },
+                children: {},
+                value: 'Test value'
+              },
+              'vmap:Test2': {
+                attributes: {
+                  test2Attribute: 'test2Attribute content',
+                  test2Attribute2: 'test2Attribute2 content'
+                },
+                children: {},
+                value: 'Test2 value'
+              }
+            },
+            value: 'Extension value'
+          }
+        },
+        value: null
+      });
+    });
+  });
+});

--- a/spec/samples/correct-vmap-with-extension.xml
+++ b/spec/samples/correct-vmap-with-extension.xml
@@ -1,0 +1,58 @@
+<vmap:VMAP xmlns:vmap="http://www.iab.net/vmap-1.0" version="1.0">
+
+  <vmap:AdBreak breakType="linear" breakId="mypre" timeOffset="start">
+
+    <vmap:Extensions>
+      <vmap:Extension extAttribute="extAttribute content" extAttribute2="extAttribute2 content">
+        Extension value
+        <vmap:Test testAttribute="testAttribute content" testAttribute2="testAttribute2 content">
+          Test value
+        </vmap:Test>
+        <vmap:Test2 test2Attribute="test2Attribute content" test2Attribute2="test2Attribute2 content">
+          Test2 value
+        </vmap:Test2>
+      </vmap:Extension>
+      <vmap:Extension>
+        Extension2 value
+        <vmap:Child childAttribute="childAttribute content" childAttribute2="childAttribute2 content">
+          Child value
+        </vmap:Child>
+      </vmap:Extension>
+    </vmap:Extensions>
+
+    <vmap:AdSource allowMultipleAds="true" followRedirects="true" id="1">
+      <vmap:VASTAdData>
+        <VAST version="3.0" xsi:noNamespaceSchemaLocation="vast.xsd">
+        </VAST>
+      </vmap:VASTAdData>
+    </vmap:AdSource>
+    <vmap:TrackingEvents>
+      <vmap:Tracking event="breakStart">http://server.com/breakstart</vmap:Tracking>
+      <vmap:Tracking event="breakEnd">http://server.com/breakend</vmap:Tracking>
+      <vmap:Tracking event="breakEnd">http://server.com/breakend2</vmap:Tracking>
+      <vmap:Tracking event="error">http://server.com/error?[ERRORCODE]</vmap:Tracking>
+    </vmap:TrackingEvents>
+  </vmap:AdBreak>
+
+  <vmap:AdBreak breakType="linear" breakId="myid" timeOffset="00:10:23.125">
+    <vmap:AdSource allowMultipleAds="true" followRedirects="true" id="2">
+      <vmap:VASTAdData>
+        <VAST version="3.0" xsi:noNamespaceSchemaLocation="vast.xsd">...
+        </VAST>
+      </vmap:VASTAdData>
+    </vmap:AdSource>
+    <vmap:TrackingEvents>
+      <vmap:Tracking event="breakStart">http://server.com/breakstart</vmap:Tracking>
+    </vmap:TrackingEvents>
+  </vmap:AdBreak>
+
+  <vmap:AdBreak breakType="linear" breakId="mypost" timeOffset="end">
+    <vmap:AdSource allowMultipleAds="true" followRedirects="true" id="3">
+    <vmap:AdTagURI>http://server.com/vast.xml</vmap:AdTagURI>
+    </vmap:AdSource>
+    <vmap:TrackingEvents>
+      <vmap:Tracking event="breakStart">http://server.com/breakstart</vmap:Tracking>
+    </vmap:TrackingEvents>
+  </vmap:AdBreak>
+
+</vmap:VMAP>

--- a/spec/samples/correct-vmap-with-extension.xml
+++ b/spec/samples/correct-vmap-with-extension.xml
@@ -1,7 +1,5 @@
 <vmap:VMAP xmlns:vmap="http://www.iab.net/vmap-1.0" version="1.0">
-
   <vmap:AdBreak breakType="linear" breakId="mypre" timeOffset="start">
-
     <vmap:Extensions>
       <vmap:Extension extAttribute="extAttribute content" extAttribute2="extAttribute2 content">
         Extension value
@@ -33,26 +31,4 @@
       <vmap:Tracking event="error">http://server.com/error?[ERRORCODE]</vmap:Tracking>
     </vmap:TrackingEvents>
   </vmap:AdBreak>
-
-  <vmap:AdBreak breakType="linear" breakId="myid" timeOffset="00:10:23.125">
-    <vmap:AdSource allowMultipleAds="true" followRedirects="true" id="2">
-      <vmap:VASTAdData>
-        <VAST version="3.0" xsi:noNamespaceSchemaLocation="vast.xsd">...
-        </VAST>
-      </vmap:VASTAdData>
-    </vmap:AdSource>
-    <vmap:TrackingEvents>
-      <vmap:Tracking event="breakStart">http://server.com/breakstart</vmap:Tracking>
-    </vmap:TrackingEvents>
-  </vmap:AdBreak>
-
-  <vmap:AdBreak breakType="linear" breakId="mypost" timeOffset="end">
-    <vmap:AdSource allowMultipleAds="true" followRedirects="true" id="3">
-    <vmap:AdTagURI>http://server.com/vast.xml</vmap:AdTagURI>
-    </vmap:AdSource>
-    <vmap:TrackingEvents>
-      <vmap:Tracking event="breakStart">http://server.com/breakstart</vmap:Tracking>
-    </vmap:TrackingEvents>
-  </vmap:AdBreak>
-
 </vmap:VMAP>

--- a/spec/samples/parsing-example.xml
+++ b/spec/samples/parsing-example.xml
@@ -1,0 +1,9 @@
+<vmap:Extension extAttribute="extAttribute content" extAttribute2="extAttribute2 content">
+  Extension value
+  <vmap:Test testAttribute="testAttribute content" testAttribute2="testAttribute2 content">
+    Test value
+  </vmap:Test>
+  <vmap:Test2 test2Attribute="test2Attribute content" test2Attribute2="test2Attribute2 content">
+    Test2 value
+  </vmap:Test2>
+</vmap:Extension>

--- a/src/adbreak.js
+++ b/src/adbreak.js
@@ -31,8 +31,8 @@ class VMAPAdBreak {
           }
           break;
         case 'Extensions':
-          this.extensions = childrenByName(node, 'vmap:Extension').map(
-            extension => parseXMLNode(extension)
+          this.extensions = childrenByName(node, 'Extension').map(extension =>
+            parseXMLNode(extension)
           );
           break;
       }

--- a/src/adbreak.js
+++ b/src/adbreak.js
@@ -1,4 +1,5 @@
 import VMAPAdSource from './adsource';
+import { childrenByName, parseXMLNode } from './parser_utils';
 
 class VMAPAdBreak {
   constructor(xml) {
@@ -30,7 +31,9 @@ class VMAPAdBreak {
           }
           break;
         case 'Extensions':
-          this.extensions = node.childNodes;
+          this.extensions = childrenByName(node, 'vmap:Extension').map(
+            extension => parseXMLNode(extension)
+          );
           break;
       }
     }

--- a/src/parser_utils.js
+++ b/src/parser_utils.js
@@ -1,0 +1,78 @@
+/**
+ * Returns all the elements of the given node which nodeName match the given name.
+ * @param  {any} node - The node to use to find the matches.
+ * @param  {any} name - The name to look for.
+ * @return {Array}
+ */
+function childrenByName(node, name) {
+  const children = [];
+  const childNodes = node.childNodes;
+
+  for (let childKey in childNodes) {
+    const child = childNodes[childKey];
+
+    if (child.nodeName === name) {
+      children.push(child);
+    }
+  }
+  return children;
+}
+
+/**
+ * Parses a node text (for legacy support).
+ * @param  {Object} node - The node to parse the text from.
+ * @return {String}
+ */
+function parseNodeText(node) {
+  return (
+    node &&
+    node.childNodes &&
+    [...node.childNodes]
+      .filter(node => node.nodeName === '#text')
+      .reduce((previous, current) => previous + current.textContent.trim(), '')
+  );
+}
+
+/**
+ * Parses an XML node recursively.
+ * @param  {Object} node - The node to parse.
+ * @return {Object}
+ */
+function parseXMLNode(node) {
+  const parsedNode = {};
+
+  const value = parseNodeText(node);
+  if (value) {
+    parsedNode.value = value;
+  }
+
+  const nodeAttrs = node.attributes;
+  if (nodeAttrs) {
+    for (let nodeAttrKey in nodeAttrs) {
+      const nodeAttr = nodeAttrs[nodeAttrKey];
+
+      if (nodeAttr.nodeName && nodeAttr.nodeValue) {
+        if (!parsedNode.attributes) {
+          parsedNode.attributes = {};
+        }
+        parsedNode.attributes[nodeAttr.nodeName] = nodeAttr.nodeValue;
+      }
+    }
+  }
+
+  [...node.childNodes]
+    .filter(
+      childNode =>
+        childNode.nodeName !== '#text' && childNode.nodeName !== '#comment'
+    )
+    .forEach(childNode => {
+      if (!parsedNode.children) {
+        parsedNode.children = {};
+      }
+      parsedNode.children[childNode.nodeName] = parseXMLNode(childNode);
+    });
+
+  return parsedNode;
+}
+
+export { childrenByName, parseNodeText, parseXMLNode };

--- a/src/parser_utils.js
+++ b/src/parser_utils.js
@@ -5,22 +5,12 @@
  * @return {Array}
  */
 function childrenByName(node, name) {
-  const children = [];
-  const childNodes = node.childNodes;
-
-  for (let childKey in childNodes) {
-    const child = childNodes[childKey];
-
-    if (
+  return [...node.childNodes].filter(
+    child =>
       child.nodeName === name ||
-      (child.nodeName &&
-        child.nodeName.match(/vmap:(.*)/) &&
-        child.nodeName.match(/vmap:(.*)/)[1] === name)
-    ) {
-      children.push(child);
-    }
-  }
-  return children;
+      name === `vmap:${child.nodeName}` ||
+      child.nodeName === `vmap:${name}`
+  );
 }
 
 /**
@@ -50,16 +40,10 @@ function parseXMLNode(node) {
     value: null
   };
 
-  const value = parseNodeText(node);
-  if (value) {
-    parsedNode.value = value;
-  }
+  parsedNode.value = parseNodeText(node) || null;
 
-  const nodeAttrs = node.attributes;
-  if (nodeAttrs) {
-    for (let nodeAttrKey in nodeAttrs) {
-      const nodeAttr = nodeAttrs[nodeAttrKey];
-
+  if (node.attributes) {
+    [...node.attributes].forEach(nodeAttr => {
       if (
         nodeAttr.nodeName &&
         nodeAttr.nodeValue !== undefined &&
@@ -67,7 +51,7 @@ function parseXMLNode(node) {
       ) {
         parsedNode.attributes[nodeAttr.nodeName] = nodeAttr.nodeValue;
       }
-    }
+    });
   }
 
   [...node.childNodes]

--- a/src/parser_utils.js
+++ b/src/parser_utils.js
@@ -11,7 +11,12 @@ function childrenByName(node, name) {
   for (let childKey in childNodes) {
     const child = childNodes[childKey];
 
-    if (child.nodeName === name) {
+    if (
+      child.nodeName === name ||
+      (child.nodeName &&
+        child.nodeName.match(/vmap:(.*)/) &&
+        child.nodeName.match(/vmap:(.*)/)[1] === name)
+    ) {
       children.push(child);
     }
   }
@@ -39,7 +44,11 @@ function parseNodeText(node) {
  * @return {Object}
  */
 function parseXMLNode(node) {
-  const parsedNode = {};
+  const parsedNode = {
+    attributes: {},
+    children: {},
+    value: null
+  };
 
   const value = parseNodeText(node);
   if (value) {
@@ -51,10 +60,11 @@ function parseXMLNode(node) {
     for (let nodeAttrKey in nodeAttrs) {
       const nodeAttr = nodeAttrs[nodeAttrKey];
 
-      if (nodeAttr.nodeName && nodeAttr.nodeValue) {
-        if (!parsedNode.attributes) {
-          parsedNode.attributes = {};
-        }
+      if (
+        nodeAttr.nodeName &&
+        nodeAttr.nodeValue !== undefined &&
+        nodeAttr.nodeValue !== null
+      ) {
         parsedNode.attributes[nodeAttr.nodeName] = nodeAttr.nodeValue;
       }
     }
@@ -66,9 +76,6 @@ function parseXMLNode(node) {
         childNode.nodeName !== '#text' && childNode.nodeName !== '#comment'
     )
     .forEach(childNode => {
-      if (!parsedNode.children) {
-        parsedNode.children = {};
-      }
       parsedNode.children[childNode.nodeName] = parseXMLNode(childNode);
     });
 

--- a/src/vmap.js
+++ b/src/vmap.js
@@ -1,4 +1,5 @@
 import VMAPAdBreak from './adbreak';
+import { childrenByName, parseXMLNode } from './parser_utils';
 
 class VMAP {
   constructor(xml) {
@@ -21,7 +22,9 @@ class VMAP {
           this.adBreaks.push(new VMAPAdBreak(node));
           break;
         case 'Extensions':
-          this.extensions = node.childNodes;
+          this.extensions = childrenByName(node, 'Extension').map(extension =>
+            parseXMLNode(extension)
+          );
           break;
       }
     }


### PR DESCRIPTION
Improved the parsing of adbreak extensions contained in the VMAP response.

Since no guidelines are specified for the content of extensions, the XML is parsed recursively with all its children