### PR TITLE
fix: Point module import to dist/vmap-js.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=12.22.1"
   },
   "main": "dist/vmap-js-node.js",
-  "module": "src/index.js",
+  "module": "dist/vmap-js.js",
   "scripts": {
     "test": "jest",
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
If package.json:module points to the source package it break the compatibility with older browsers as the sources include ES6 code. Using the transpiled distributable fixes this issue.

It would make sense to change from `module` to `browser` though to follow the same system that @dailymotion/vast-client