### PR TITLE
fix: switch build config for browser from iife to esm

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
     input: 'src/index.js',
     output: {
       file: path.resolve(__dirname, 'dist', 'vmap-js.js'),
-      format: 'iife',
+      format: 'es',
       name: 'VMAP',
     },
     plugins,


### PR DESCRIPTION
Issue with ESM imports were not due to bad config in the package.json but the fact we build the dist for browser as IIFE instead of ESM module. 
The issue was silent until fix in https://github.com/dailymotion/vmap-js/pull/38 as before package.json were redirecting directly to the source code. 